### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -22,5 +22,5 @@ If you want to fix a bug or add a new feature, please follow this process:
 **In any cases, make sure your code has been tested thorougly**
 
 
-#Thanks
+# Thanks
 I really appreciate all contributions, I made this tool because many in my surrounding needed it and I hope Localizations will belong to all of us.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Localizations 0.2
+# Localizations 0.2
 
 Localizations is an OS X app that manages your Xcode project localization files (.strings).
 
@@ -35,7 +35,7 @@ My intentions with this app are to fill this void and, by making it open source,
 
 This project is completely open source and under the MIT license. So enjoy and have fun. For full details please see license.md
 
-##Screenshots
+## Screenshots
 ![Screenshot](https://github.com/athiercelin/Localizations/blob/master/Screenshots/localization-0.1-4.png?raw=true)
 ![Screenshot](https://github.com/athiercelin/Localizations/blob/master/Screenshots/localization-0.1-5.png?raw=true)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
